### PR TITLE
walletconnector v2 chains fix

### DIFF
--- a/src/hooks/web3/index.tsx
+++ b/src/hooks/web3/index.tsx
@@ -169,7 +169,11 @@ function useWeb3ReactConnectors({ defaultChainId, provider, jsonRpcUrlMap }: Pro
       rpcMap: urlMap,
       projectId: 'c6c9bacd35afa3eb9e6cccf6d8464395',
       // this requires the connecting wallet to support eth mainnet
-      chains: [SupportedChainId.MAINNET],
+      chains: [
+        SupportedChainId.MAINNET,
+        // include the defaultChainId if specified and not already included
+        ...((defaultChainId !== SupportedChainId.MAINNET) ? [defaultChainId] : []),
+      ],
       optionalChains: [...L1_CHAIN_IDS, ...L2_CHAIN_IDS],
       optionalMethods: ['eth_signTypedData', 'eth_signTypedData_v4', 'eth_sign'],
       qrModalOptions: {

--- a/src/hooks/web3/index.tsx
+++ b/src/hooks/web3/index.tsx
@@ -172,7 +172,7 @@ function useWeb3ReactConnectors({ defaultChainId, provider, jsonRpcUrlMap }: Pro
       chains: [
         SupportedChainId.MAINNET,
         // include the defaultChainId if specified and not already included
-        ...((defaultChainId !== SupportedChainId.MAINNET) ? [defaultChainId] : []),
+        ...(defaultChainId && defaultChainId !== SupportedChainId.MAINNET ? [defaultChainId] : []),
       ],
       optionalChains: [...L1_CHAIN_IDS, ...L2_CHAIN_IDS],
       optionalMethods: ['eth_signTypedData', 'eth_signTypedData_v4', 'eth_sign'],


### PR DESCRIPTION
The walletconnect v2 connector will throw an error if the `defaultChainId` is not included in the supplied `chains`.

See here - https://github.com/Uniswap/web3-react/blob/bd267025f06b5808fd6ccc4e18dde4d400c4076a/packages/walletconnect-v2/src/utils.ts#L102-L119

This package's `<Provider />` (usually imported as `Web3Provider`) component has the connector's `chains` hard-coded to eth mainnet. The components/widgets that consume from this Provider will throw an error when attempting to use a default chain other than eth mainnet.